### PR TITLE
Replaced outdated police shooting api

### DIFF
--- a/application/main.py
+++ b/application/main.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
         # entity_key.cdc_state_tests,
         entity_key.cdc_state_vaccinations,
         entity_key.cdc_county_deaths,
-        # entity_key.police_fatal_shootings,
+        entity_key.police_fatal_shootings,
         entity_key.apha_racism_declarations,
         # entity_key.ucla_covid_behind_bars,
         # entity_key.osha_closed_complaints,

--- a/police/entity.py
+++ b/police/entity.py
@@ -7,7 +7,8 @@ import requests
 import csv
 import io
 
-URL = 'https://raw.githubusercontent.com/washingtonpost/data-police-shootings/master/fatal-police-shootings-data.csv'
+URL = 'https://raw.githubusercontent.com/washingtonpost/data-police-shootings/master/v1/fatal-police-shootings-data.csv'
+
 
 race_ethnicity_mapping = {
     'A': 'Asian',


### PR DESCRIPTION
The url we were using to access the csv gives a 404 error. I found a similar csv. Turns out there is a new v2 of the data with a couple of changes. For the sake of speed, although v1 isnt being supported im just going to update the url to a working v1 so we can handle the v2 changes later. These changes involve database changes and a new one to many relationship with the ethnicities. Will do that later. V1 isnt being populated anymore. 
 

The V2 release branch and readme notes 

https://github.com/washingtonpost/data-police-shootings/tree/master/v2 